### PR TITLE
VNDLY-40599: Replace force_text with force_str

### DIFF
--- a/tenant_schemas/__init__.py
+++ b/tenant_schemas/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'tenant_schemas.apps.TenantSchemaConfig'
 
-__version__ = "v1.9.0-vndly-0.0.1"
+__version__ = "v1.9.0-vndly-0.0.2"

--- a/tenant_schemas/postgresql_backend/introspection.py
+++ b/tenant_schemas/postgresql_backend/introspection.py
@@ -10,7 +10,7 @@ try:
     from django.db.models.indexes import Index
 except ImportError:
     Index = None
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 fields = FieldInfo._fields
 if 'default' not in fields:
@@ -213,9 +213,9 @@ class DatabaseSchemaIntrospection(BaseDatabaseIntrospection):
 
         return [
             FieldInfo(*(
-                (force_text(line[0]),) +
+                (force_str(line[0]),) +
                 line[1:6] +
-                (field_map[force_text(line[0])][0] == 'YES', field_map[force_text(line[0])][1])
+                (field_map[force_str(line[0])][0] == 'YES', field_map[force_str(line[0])][1])
             )) for line in cursor.description
         ]
 


### PR DESCRIPTION
Use django.utils.encoding.force_str in place of django.utils.encoding.force_text, which doesn't exist in Django 4.