### PR TITLE
VNDLY-41414: Middleware will start to require 1 positional argument.

### DIFF
--- a/tenant_schemas/__init__.py
+++ b/tenant_schemas/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'tenant_schemas.apps.TenantSchemaConfig'
 
-__version__ = "v1.9.0-vndly-0.0.3"
+__version__ = "v1.9.0-vndly-0.0.4"

--- a/tenant_schemas/test/client.py
+++ b/tenant_schemas/test/client.py
@@ -3,7 +3,7 @@ from tenant_schemas.middleware import TenantMiddleware
 
 
 class TenantRequestFactory(RequestFactory):
-    tm = TenantMiddleware()
+    tm = TenantMiddleware(lambda r:r)
 
     def __init__(self, tenant, **defaults):
         super(TenantRequestFactory, self).__init__(**defaults)
@@ -42,7 +42,7 @@ class TenantRequestFactory(RequestFactory):
 
 
 class TenantClient(Client):
-    tm = TenantMiddleware()
+    tm = TenantMiddleware(lambda r:r)
 
     def __init__(self, tenant, enforce_csrf_checks=False, **defaults):
         super(TenantClient, self).__init__(enforce_csrf_checks, **defaults)

--- a/tenant_schemas/tests/test_routes.py
+++ b/tenant_schemas/tests/test_routes.py
@@ -32,7 +32,7 @@ class RoutesTestCase(BaseTestCase):
     def setUp(self):
         super(RoutesTestCase, self).setUp()
         self.factory = RequestFactory()
-        self.tm = TenantMiddleware()
+        self.tm = TenantMiddleware(lambda r:r)
         self.dtm = DefaultTenantMiddleware()
 
         self.tenant_domain = 'tenant.test.com'


### PR DESCRIPTION
Needed for Django 4 upgrade.  Will pull in new version of this package at same time as Django upgrade.